### PR TITLE
Don't show grind.sh help and alert user to file permissions issues

### DIFF
--- a/grind.sh
+++ b/grind.sh
@@ -19,6 +19,7 @@ spinner_pid=""
 # Help                                      #
 #############################################
 show_help() {
+  echo "::grinder-help-start::"
   cat << EOF
 
 Usage: grind.sh --command <cmd> [--input <path>] [--output <path>] [--verbose|--quiet]
@@ -48,6 +49,7 @@ Deployment Event Format:
     - start_time and/or end_time (at least one required)
   Accepted input format: JSON array or newline-delimited JSON (JSONL)
 EOF
+echo "::grinder-help-end::"
 }
 
 #############################################
@@ -125,6 +127,16 @@ scan_artifacts() {
     exit 1
   }
 
+  [[ "$quiet" == false ]] && echo "📦 Scanning artifacts... this may take some time."
+
+  mkdir -p "$output_dir"
+  if ! touch "$output_dir/.write_test" 2>/dev/null; then
+    echo "❌ Cannot write to output directory '$output_dir'."
+    echo "   Make sure it is mounted correctly and writable by UID $(id -u) inside the container."
+    exit 1
+  fi
+  rm -f "$output_dir/.write_test"
+ 
   if run_cmd /opt/docker/bin/goatrodeo -b "$input_dir" -o "$output_dir"; then
     [[ "$quiet" == false ]] && echo "✅ Scan successful"
   else

--- a/grind.sh
+++ b/grind.sh
@@ -265,7 +265,10 @@ if [[ "$verbose" == true && "$quiet" == true ]]; then
   exit 1
 fi
 
-fail_if_unset "$SPICE_PASS_ENV_VAR"
+if [[ "$command" != "scan-artifacts" ]]; then
+  fail_if_unset "$SPICE_PASS_ENV_VAR"
+fi
+
 check_binaries
 
 if [[ "$verbose" == true ]]; then

--- a/grinder.sh
+++ b/grinder.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DOCKER_IMAGE="grinder"
+DOCKER_IMAGE="ghcr.io/spice-labs-inc/grinder:latest"
 ci_mode=false
 pull_latest=true
 

--- a/grinder.sh
+++ b/grinder.sh
@@ -71,11 +71,18 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Validate Spice Pass
-if [[ -z "${SPICE_PASS:-}" ]]; then
-  echo "❌ SPICE_PASS environment variable must be set"
-  exit 1
-fi
+# Validate Spice Pass only for commands that require it
+case "$command" in
+  scan-artifacts)
+    ;; # skip check
+  *)
+    if [[ -z "${SPICE_PASS:-}" ]]; then
+      echo "❌ SPICE_PASS environment variable must be set for command '$command'"
+      exit 1
+    fi
+    ;;
+esac
+
 
 # Pull image unless skipped
 if [[ "$pull_latest" == true ]]; then

--- a/grinder.sh
+++ b/grinder.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DOCKER_IMAGE="ghcr.io/spice-labs-inc/grinder:latest"
+DOCKER_IMAGE="grinder"
 ci_mode=false
 pull_latest=true
 
@@ -33,6 +33,7 @@ Options:
 EOF
 }
 
+# Parse arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --command)
@@ -70,35 +71,62 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Validate Spice Pass
 if [[ -z "${SPICE_PASS:-}" ]]; then
-  echo "Error: SPICE_PASS environment variable must be set"
+  echo "❌ SPICE_PASS environment variable must be set"
   exit 1
 fi
 
+# Pull image unless skipped
 if [[ "$pull_latest" == true ]]; then
-  docker pull "$DOCKER_IMAGE" >/dev/null
+  docker pull "$DOCKER_IMAGE" > /dev/null
 fi
 
+# Prepare args
 args=(--command "$command")
+
+# Default to current dir as input if not set
 [[ -z "$input" ]] && input="$PWD"
 args+=(--input /mnt/input)
-[[ -n "$output" ]] && args+=(--output /mnt/output)
 
-# If CI mode, default to --quiet unless overridden by user
+# Ensure output directory exists for commands that write to it
+if [[ "$command" == "scan-artifacts" || "$command" == "run" ]]; then
+  if [[ -z "$output" ]]; then
+    output="$(mktemp -d)"
+  else
+    mkdir -p "$output"
+  fi
+  if [[ ! -w "$output" ]]; then
+    echo "❌ Output directory '$output' is not writable. Please fix permissions and try again."
+    exit 1
+  fi
+  args+=(--output /mnt/output)
+fi
+
+# Default to --quiet in CI unless overridden
 if [[ "$ci_mode" == true && ! " ${extra_args[*]} " =~ " --verbose " && ! " ${extra_args[*]} " =~ " --quiet " ]]; then
   args+=(--quiet)
 fi
 
-volumes=(-v "$PWD:/mnt/host")
-[[ -n "$input" ]] && volumes+=(-v "$input:/mnt/input")
+# Prepare Docker flags
+volumes=(-v "$input:/mnt/input")
 [[ -n "$output" ]] && volumes+=(-v "$output:/mnt/output")
 
-# Always pass through SPICE_PASS
 flags=(-e SPICE_PASS --rm)
-
-# If stdin is needed (events)
 [[ "$command" == "upload-deployment-events" ]] && flags+=(-i)
 
 echo "🚀 Running grinder with command: $command"
+echo "📁 Mounting input:  $input"
+[[ -n "$output" ]] && echo "📁 Mounting output: $output"
 
-docker run "${flags[@]}" "${volumes[@]}" "$DOCKER_IMAGE" "${args[@]}" "${extra_args[@]}"
+# Run and filter output
+docker run "${flags[@]}" "${volumes[@]}" "$DOCKER_IMAGE" "${args[@]}" "${extra_args[@]}" \
+  > >(sed 's/\bgrind\.sh\b/grinder.sh/g' | sed '/::grinder-help-start::/,/::grinder-help-end::/d') \
+  2> >(tee /dev/stderr) || {
+    echo
+    echo "❌ Grinder failed."
+    show_help
+    exit 1
+  }
+
+


### PR DESCRIPTION
- filter docker output in grinder.sh wrapper to not show grind.sh help, but show grinder.sh help instead
- let the user know if there are output dir permissions issues they need to resolve
- don't require SPICE_PASS env var to be set to run scan-artifacts.